### PR TITLE
Add bottom LIN-81258 stack fixture

### DIFF
--- a/stack-fixture/lin-81258-bottom.md
+++ b/stack-fixture/lin-81258-bottom.md
@@ -1,0 +1,1 @@
+LIN-81258 native stack fixture: bottom


### PR DESCRIPTION
First layer of the native GitHub stack used to test LIN-81258 in local Linear.