### PR TITLE
Add middle LIN-81258 stack fixture

### DIFF
--- a/stack-fixture/lin-81258-middle.md
+++ b/stack-fixture/lin-81258-middle.md
@@ -1,0 +1,1 @@
+LIN-81258 native stack fixture: middle


### PR DESCRIPTION
Second layer of the native GitHub stack used to test LIN-81258. It builds on the bottom fixture pull request.