### PR TITLE
Add top LIN-81258 stack fixture

### DIFF
--- a/stack-fixture/lin-81258-top.md
+++ b/stack-fixture/lin-81258-top.md
@@ -1,0 +1,1 @@
+LIN-81258 native stack fixture: top


### PR DESCRIPTION
Final layer of the native GitHub stack used to test LIN-81258. Merge this pull request from local Linear.